### PR TITLE
Run fuse.cmd on Windows

### DIFF
--- a/src/Fuse/Daemon.ts
+++ b/src/Fuse/Daemon.ts
@@ -102,7 +102,11 @@ export class FuseDaemon {
             return this.fuseClient;
         }
 
-        this.fuseClient = spawn("fuse", ['daemon-client', 'vscode client']);
+        var fuse = process.platform === "win32"
+            ? "fuse.cmd"
+            : "fuse";
+
+        this.fuseClient = spawn(fuse, ['daemon-client', 'vscode client']);
 
         this.fuseClient.stdout.on('data', FuseDaemon.instance.onData);
         this.fuseClient.stderr.on('data', FuseDaemon.instance.onError);


### PR DESCRIPTION
This makes us able to connect to the Fuse Daemon when using the new
Fuse Studio distribution (a.k.a. fuse X), which is managed by NPM.

NPM automatically creates this wrapper cmd-file for us when installing,
and internal fuse-executables are no longer found in PATH.